### PR TITLE
BR2_PACKAGE_LIBFTDI typo

### DIFF
--- a/package/openocd_cypress/Config.in
+++ b/package/openocd_cypress/Config.in
@@ -3,7 +3,7 @@ config BR2_PACKAGE_OPENOCD_CYPRESS
         depends on BR2_TOOLCHAIN_HAS_THREADS #
         select BR2_PACKAGE_LIBUSB
         select BR2_PACKAGE_LIBUSB_COMPAT
-        select BR2_PACKAGE_LIBFTD
+        select BR2_PACKAGE_LIBFTDI
         select BR2_PACKAGE_HIDAPI
         help
            OpenOCD for Cypress

--- a/package/openocd_esp32/Config.in
+++ b/package/openocd_esp32/Config.in
@@ -3,7 +3,7 @@ config BR2_PACKAGE_OPENOCD_ESP32
         depends on BR2_TOOLCHAIN_HAS_THREADS #
         select BR2_PACKAGE_LIBUSB
         select BR2_PACKAGE_LIBUSB_COMPAT
-        select BR2_PACKAGE_LIBFTD
+        select BR2_PACKAGE_LIBFTDI
         help
            OpenOCD for esp32
 

--- a/package/openocd_ly/Config.in
+++ b/package/openocd_ly/Config.in
@@ -3,7 +3,7 @@ config BR2_PACKAGE_OPENOCD_LY
         depends on BR2_TOOLCHAIN_HAS_THREADS #
         select BR2_PACKAGE_LIBUSB
         select BR2_PACKAGE_LIBUSB_COMPAT
-        select BR2_PACKAGE_LIBFTD
+        select BR2_PACKAGE_LIBFTDI
         help
            OpenOCD
 

--- a/package/openocd_nrf9160/Config.in
+++ b/package/openocd_nrf9160/Config.in
@@ -3,7 +3,7 @@ config BR2_PACKAGE_OPENOCD_NRF9160
         depends on BR2_TOOLCHAIN_HAS_THREADS #
         select BR2_PACKAGE_LIBUSB
         select BR2_PACKAGE_LIBUSB_COMPAT
-        select BR2_PACKAGE_LIBFTD
+        select BR2_PACKAGE_LIBFTDI
         help
            OpenOCD for nrf9160
 

--- a/package/openocd_pn7362/Config.in
+++ b/package/openocd_pn7362/Config.in
@@ -3,7 +3,7 @@ config BR2_PACKAGE_OPENOCD_PN7362
         depends on BR2_TOOLCHAIN_HAS_THREADS #
         select BR2_PACKAGE_LIBUSB
         select BR2_PACKAGE_LIBUSB_COMPAT
-        select BR2_PACKAGE_LIBFTD
+        select BR2_PACKAGE_LIBFTDI
         help
            OpenOCD for PN7362
 

--- a/package/openocd_zephyr/Config.in
+++ b/package/openocd_zephyr/Config.in
@@ -3,7 +3,7 @@ config BR2_PACKAGE_OPENOCD_ZEPHYR
         depends on BR2_TOOLCHAIN_HAS_THREADS #
         select BR2_PACKAGE_LIBUSB
         select BR2_PACKAGE_LIBUSB_COMPAT
-        select BR2_PACKAGE_LIBFTD
+        select BR2_PACKAGE_LIBFTDI
         select BR2_PACKAGE_HIDAPI
         help
            OpenOCD for Zephyr


### PR DESCRIPTION
Possibly typo (`BR2_PACKAGE_LIBFTD`).  Doesn't seem to be fatal, because top-level `Config.in` already selects both `BR2_PACKAGE_LIBFTDI` and `BR2_PACKAGE_LIBFTDI1`